### PR TITLE
Kraafter entry into the webring

### DIFF
--- a/src/_data/webring.mjs
+++ b/src/_data/webring.mjs
@@ -34,4 +34,9 @@ export default [
     name: "Munsterlandr",
     url: "https://www.munsterlandr.monster",
   },
+  {
+    id: "kraaft",
+    name: "Kraaftersite",
+    url: "https://kraaftersite-v3.vercel.app/", //will be changed to kraafter.me once v2 is sunset
+  },
 ];


### PR DESCRIPTION
V3 preview link:
[https://kraaftersite-v3.vercel.app/](https://kraaftersite-v3.vercel.app/)

V2 under domain:
[https://kraafter.me/](https://kraafter.me/)